### PR TITLE
force-bump animal well

### DIFF
--- a/index/animal_well.toml
+++ b/index/animal_well.toml
@@ -6,4 +6,4 @@ default_url = "https://github.com/ScipioWright/Archipelago-SW/releases/download/
 "0.4.2" = {}
 "0.5.0" = {}
 "0.5.2" = {}
-"0.5.3" = {}
+"0.5.4" = {}


### PR DESCRIPTION
Upstream replaced the apworld artifact for 0.5.3 and also released 0.5.4 with the same artifact.  0.5.3 might as well be gone.