### PR TITLE
Update Pokepelago to 0.6.1 (#3)

### DIFF
--- a/index/pokepelago.toml
+++ b/index/pokepelago.toml
@@ -5,3 +5,4 @@ default_url = "https://github.com/dowlle/PokepelagoClient/releases/download/v{{v
 [versions]
 "0.4.4" = {}
 "0.5.1" = {}
+"0.6.1" = {}


### PR DESCRIPTION
Redirected from https://github.com/mooinglemur/Archipelago-index/pull/1

---  

Adds version 0.6.1 to the Pokepelago index entry.

- Release: [dowlle/PokepelagoClient v0.6.1](https://github.com/dowlle/PokepelagoClient/releases/tag/v0.6.1) (2026-04-23)
- Resolved download URL via the existing `default_url` template:
  https://github.com/dowlle/PokepelagoClient/releases/download/v0.6.1/pokepelago.apworld
- Adds one line to `index/pokepelago.toml`; no other changes.

Note: this version was not yet published on `Eijebong/Archipelago-index` before that index stopped accepting submissions; landing it here covers the gap.

The same change has been merged on my fork at [dowlle/Archipelago-index#3](https://github.com/dowlle/Archipelago-index/pull/3). I also ran an automated source-level security audit against this version on the fork — verdict was NEEDS_REVIEW with no CRITICAL findings (the runtime code is clean; flags were on developer-only `tools/` scripts that ship with the .apworld but aren't loaded by `__init__.py`). Happy to share the report here if useful.