### PR TITLE
Re-enable TEVI and update to 0.7.1

### DIFF
--- a/index/tevi.toml
+++ b/index/tevi.toml
@@ -1,7 +1,5 @@
 name = "Tevi"
 home = "https://discord.com/channels/731205301247803413/1320015979736203304"
-# Has a bug where it leaks state between different slots running the game
-disabled = true
 
 [versions]
-"0.6.6" = { url = "https://github.com/BlackSoulKnight/Tevi_Randomizer/releases/download/v1.4.6/tevi.apworld" }
+"0.7.1" = { url = "https://github.com/BlackSoulKnight/Tevi_Randomizer/releases/download/v1.5.1/tevi.apworld" }


### PR DESCRIPTION
Was disabled for having logic bleed between multiple TEVI worlds. This was fixed in https://github.com/BlackSoulKnight/Tevi_Archipelago/pull/7