### PR TITLE
Add pokepelago 0.6.2

### DIFF
--- a/index/pokepelago.toml
+++ b/index/pokepelago.toml
@@ -6,3 +6,4 @@ default_url = "https://github.com/dowlle/PokepelagoClient/releases/download/v{{v
 "0.4.4" = {}
 "0.5.1" = {}
 "0.6.1" = {}
+"0.6.2" = {}


### PR DESCRIPTION
Adds pokepelago 0.6.2 (current release).

pokepelago is maintained by Dowlle (Appie on Discord). Latest release: https://github.com/dowlle/PokepelagoClient/releases/tag/v0.6.2

The 0.6.2 `.apworld` passed a full 10-hook generation fuzz suite (default + no-restrictive-starts + 8 correctness checks at 1.0x multiplier) plus a security audit — all green. Fuzz run for reference: https://github.com/dowlle/Archipelago-index/actions/runs/26660466715
