### PR TITLE
Add Status Lock apworld

### DIFF
--- a/index/status_lock.toml
+++ b/index/status_lock.toml
@@ -5,3 +5,4 @@ default_url = "https://github.com/guigui0246/StatusLock/releases/download/v{{ver
 [versions]
 "0.3.0" = {}
 "0.3.1" = {}
+"0.3.2" = {}

--- a/index/status_lock.toml
+++ b/index/status_lock.toml
@@ -1,0 +1,7 @@
+name = "Status Lock"
+home = "https://discord.com/channels/731205301247803413/1431916126614585435"
+default_url = "https://github.com/guigui0246/StatusLock/releases/download/v{{version}}/status_lock.apworld"
+
+[versions]
+"0.3.0" = {}
+"0.3.1" = {}


### PR DESCRIPTION
This is a meta-game that locks hint cost, release and collect behind items.

All locations are excluded meaning it can't generate by itself
To prevent conflict only 1 "player" can be generated in each multiworld.