### PR TITLE
Update Metroid Fusion to v1.22.4

### DIFF
--- a/index/metroidfusion.toml
+++ b/index/metroidfusion.toml
@@ -1,6 +1,8 @@
 name = "Metroid Fusion"
 home = "https://discord.com/channels/731205301247803413/1493332737765933137"
+default_url = "https://github.com/StalledStorm/ArchipelagoMine/releases/download/v{{version}}/metroidfusion.apworld"
 
 [versions]
 "0.0.17" = { url = "https://github.com/Rosalie-A/Archipelago/releases/download/MF-v17/metroidfusion.apworld" }
 "0.0.21+hotfix3" = { url = "https://github.com/StalledStorm/ArchipelagoMine/releases/download/v21/metroidfusion.apworld" }
+"1.22.4" = {}


### PR DESCRIPTION
Properly uses semver now. Should be no more overwriting of release artifacts anymore.