### PR TITLE
Add display name to Tetris for Gameboy

### DIFF
--- a/index/nnt.toml
+++ b/index/nnt.toml
@@ -1,4 +1,5 @@
 name = "New 'n' Tasty"
+display_name = "Oddworld: New 'n' Tasty"
 home = "https://discord.com/channels/731205301247803413/1474177461708263565"
 default_url = "https://github.com/Knuxfan24/New-n-Tasty-Archipelago/releases/download/{{version}}/nnt.apworld"
 

--- a/index/nnt.toml
+++ b/index/nnt.toml
@@ -1,5 +1,4 @@
 name = "New 'n' Tasty"
-display_name = "Oddworld: New 'n' Tasty"
 home = "https://discord.com/channels/731205301247803413/1474177461708263565"
 default_url = "https://github.com/Knuxfan24/New-n-Tasty-Archipelago/releases/download/{{version}}/nnt.apworld"
 

--- a/index/tetris_gb.toml
+++ b/index/tetris_gb.toml
@@ -1,4 +1,5 @@
 name = "Tetris"
+display_name = "Tetris (Gameboy)"
 home = "https://discord.com/channels/731205301247803413/1212629606608408576"
 default_url = "https://github.com/Alchav/Archipelago/releases/download/tetris-{{version}}/tetris_gb.apworld"
 


### PR DESCRIPTION
To differentiate it from the scores of other Tetris games that exist out there.
Note: the author of the APWorld spelled Gameboy without a space. I am following their lead.