### PR TITLE
Update Crystal Project to 0.16.0

### DIFF
--- a/index/crystal_project.toml
+++ b/index/crystal_project.toml
@@ -7,3 +7,4 @@ default_url = "https://github.com/Emerassi/CrystalProjectAPWorld/releases/downlo
 "0.9.0" = {}
 "0.11.4" = {}
 "0.13.0" = {}
+"0.16.0" = {}


### PR DESCRIPTION
Crystal Project used to not pass the fuzzer at a certain point because of how the yaml errors are handled.

This version of the Crystal Project APWorld uses the OptionError instead of the Exception when it comes to checking invalid yamls, which should pass the fuzzer.

The most recent version of the AP world mainly contains fixes.