### PR TITLE
Remove old Cuphead versions, add version alpha03d and alpha03e (0.2.16909311, 0.2.16909567)

### DIFF
--- a/index/cuphead.toml
+++ b/index/cuphead.toml
@@ -2,5 +2,5 @@ name = "Cuphead"
 home = "https://discord.com/channels/731205301247803413/1497318235438186566"
 
 [versions]
-"0.2.16909311" { url = "https://github.com/JKLeckr/Archipelago-cuphead/releases/download/alpha03d/cuphead.apworld" }
-"0.2.16909567" { url = "https://github.com/JKLeckr/Archipelago-cuphead/releases/download/alpha03e/cuphead.apworld" }
+"0.2.16909311" = { url = "https://github.com/JKLeckr/Archipelago-cuphead/releases/download/alpha03d/cuphead.apworld" }
+"0.2.16909567" = { url = "https://github.com/JKLeckr/Archipelago-cuphead/releases/download/alpha03e/cuphead.apworld" }

--- a/index/cuphead.toml
+++ b/index/cuphead.toml
@@ -1,6 +1,6 @@
 name = "Cuphead"
-home = "https://discord.com/channels/731205301247803413/1050929729844297789"
+home = "https://discord.com/channels/731205301247803413/1497318235438186566"
 
 [versions]
-"0.0.2-alpha+b" = { url = "https://github.com/JKLeckr/Archipelago-cuphead/releases/download/alpha02b/cuphead.apworld" }
-"0.0.2-alpha+f" = { url = "https://github.com/JKLeckr/Archipelago-cuphead/releases/download/alpha02f/cuphead.apworld" }
+"0.2.16909311" { url = "https://github.com/JKLeckr/Archipelago-cuphead/releases/download/alpha03d/cuphead.apworld" }
+"0.2.16909567" { url = "https://github.com/JKLeckr/Archipelago-cuphead/releases/download/alpha03e/cuphead.apworld" }


### PR DESCRIPTION
The existing versions in the index did not generate with 0.6.7 due to the world version not being numeric.  It appears they fixed that, even though the true numeric version number is only in the apworld manifest and not on the releases page.