### PR TITLE
Add Crash Team Racing (ctr) 0.1.0

### DIFF
--- a/index/ctr.toml
+++ b/index/ctr.toml
@@ -1,0 +1,6 @@
+name = "Crash Team Racing"
+home = "https://github.com/dowlle/ctr-native-ap"
+default_url = "https://github.com/dowlle/ctr-native-ap/releases/download/v{{version}}/ctr.apworld"
+
+[versions]
+"0.1.0" = {}


### PR DESCRIPTION
Adds **Crash Team Racing (PSX, 1999)** - `ctr.apworld`, first public release v0.1.0.

- **World name:** `Crash Team Racing` (apworld module `ctr`)
- **Home / releases:** https://github.com/dowlle/ctr-native-ap (the client is a decompiled native PC build with the AP client built in; the apworld source lives at https://github.com/dowlle/ctr-archipelago-apworld)
- **Release tags are semver** (`v0.1.0`), `.apworld` attached to every release, so `default_url` with `v{{version}}` works.
- **Generation:** no ROM required, no remote resources, no executable blobs in the apworld. Fuzzed with Eijebong's fuzzer (14k seeds, all options randomized, full hook suite) - green before release; failure rate well under 1%.
- Ships an `archipelago.json` manifest (world_version 0.1.0, minimum AP 0.6.7).
- Setup guide: https://github.com/dowlle/ctr-archipelago-apworld/blob/main/worlds/ctr/docs/setup_en.md
