### PR TITLE
Pokepelago 0.6.3

### DIFF
--- a/index/pokepelago.toml
+++ b/index/pokepelago.toml
@@ -7,3 +7,4 @@ default_url = "https://github.com/dowlle/PokepelagoClient/releases/download/v{{v
 "0.5.1" = {}
 "0.6.1" = {}
 "0.6.2" = {}
+"0.6.3" = {}


### PR DESCRIPTION
Adds **Pokepelago 0.6.3** (released 2026-07-03, latest stable) to the existing entry: the `default_url` template already covers it, asset verified live.

Fuzz status for 0.6.3: 5000 seeds through Eijebong's fuzzer, failure rate 0.04%
