### PR TITLE
Update SM64: Spicy Mycena 64 to 0.1.3

### DIFF
--- a/index/sm64ex_spicy.toml
+++ b/index/sm64ex_spicy.toml
@@ -4,3 +4,4 @@ default_url = "https://github.com/Alchav/Archipelago/releases/download/spicy-{{v
 
 [versions]
 "0.1.0" = {}
+"0.1.3" = {}


### PR DESCRIPTION
Since the index is missing 0.1.1 and 0.1.2, I'll also list the changes in those.
The most notable changes are logic based.

### 0.1.1
- Fixes to BITFS logic.
- Renames a PSS 1-Up location name.

### 0.1.2
- Palette option overhaul. Options are now Named Range options allowing you to pick a standard color or specify any RGB value as an int (convert hex RGB values to decimal in your calculator).
- Logic fixes for THI region connections and BBH coins.
- Fixes a server crash caused by invalid entrance hints being generated for event locations.
- A BITFS location was renamed.
- BBH Second Floor and Secret Room Vanish Cap block location checks have been reversed from their incorrect assignments.
- VCUTM text on the Levels menu is no longer overlapping other text.
- Now accepts hat color assignment. Hat will continue using shirt color for games generated before 0.1.2.

### 0.1.3
- Added trap item options.
- Renamed all Block 1-Up location checks to have the word "Block" in the name.
- Cool, Cool Mountain - Slide Shortcut Second 1-Up is only created when No Despawns is enabled, for now.
- Various logic fixes.