### PR TITLE
Update CrossCode 0.9.6

### DIFF
--- a/index/crosscode.toml
+++ b/index/crosscode.toml
@@ -16,3 +16,4 @@ default_url = "https://github.com/CodeTriangle/CCMultiworldRandomizer/releases/d
 "0.9.2" = {}
 "0.9.3" = {}
 "0.9.4" = {}
+"0.9.6" = {}


### PR DESCRIPTION
Skip 0.9.5 due to mod crashes, to avoid mod/apworld version mismatch confusion.