### PR TITLE
Update manual_pokemonstadium2challengecup_rowcc.toml (version 0.0.3)

### DIFF
--- a/index/manual_pokemonstadium2challengecup_rowcc.toml
+++ b/index/manual_pokemonstadium2challengecup_rowcc.toml
@@ -2,4 +2,4 @@ name = "Manual_PokemonStadium2ChallengeCup_rowCC"
 display_name = "Manual: Pokemon Stadium 2 Challenge Cup"
 
 [versions]
-"0.0.2" = { url = "https://github.com/row-row-row/Archipelagos/releases/download/Archipelagos/manual_pokemonstadium2challengecup_rowcc.apworld" }
+"0.0.3" = { url = "https://github.com/row-row-row/Archipelagos/releases/download/ArchipelagosUpdate/manual_pokemonstadium2challengecup_rowcc.apworld" }


### PR DESCRIPTION
Sorry if this commit is coming through twice, I was in the wrong index somehow. This is the most recent version for the manual to fix the logic and "forced" checks that existed in version 0.0.1, which also didn't make it into version 0.0.2 somehow.

Here's the direct link if the .toml is set up incorrectly: https://github.com/row-row-row/Archipelagos/releases/tag/ArchipelagosUpdate