### PR TITLE
Update Spicy Mycena 64 to v0.2.0

### DIFF
--- a/index/sm64ex_spicy.toml
+++ b/index/sm64ex_spicy.toml
@@ -5,3 +5,4 @@ default_url = "https://github.com/Alchav/Archipelago/releases/download/spicy-{{v
 [versions]
 "0.1.0" = {}
 "0.1.3" = {}
+"0.2.0" = {}


### PR DESCRIPTION
Major Spicy Mycena 64 update, pretty important to update.