### PR TITLE
Update Spicy Mycena 64 to v0.2.2

### DIFF
--- a/index/sm64ex_spicy.toml
+++ b/index/sm64ex_spicy.toml
@@ -6,3 +6,4 @@ default_url = "https://github.com/Alchav/Archipelago/releases/download/spicy-{{v
 "0.1.0" = {}
 "0.1.3" = {}
 "0.2.1" = {}
+"0.2.2" = {}


### PR DESCRIPTION
Contains logic fixes and removes a useless item (BitFS: Warp Pipes)