### PR TITLE
Update Spicy Mycena 64 to v0.2.3

### DIFF
--- a/index/sm64ex_spicy.toml
+++ b/index/sm64ex_spicy.toml
@@ -7,3 +7,4 @@ default_url = "https://github.com/Alchav/Archipelago/releases/download/spicy-{{v
 "0.1.3" = {}
 "0.2.1" = {}
 "0.2.2" = {}
+"0.2.3" = {}


### PR DESCRIPTION
Fixed Red Coin logic for Wet-Dry World.
Added detailed Universal Tracker /explain output for individual coin sources, displaying required regions, items, moves, and logic tricks for each set of coins.
Fixed the Tower of the Wing Cap Permanent Coins route so it does not incorrectly require the Coin Mastery trick.
Various other under the hood fixes.



excuse me while i go punch a wall