### PR TITLE
Fix name for Librarian Tidy Up the Arcane Library

### DIFF
--- a/index/librarian.toml
+++ b/index/librarian.toml
@@ -1,4 +1,4 @@
-name = "Librarian: Tidy up the arcane library"
+name = "Librarian Tidy Up the Arcane Library"
 home = "https://discord.com/channels/731205301247803413/1501512989923086386"
 default_url = "https://github.com/Str8UpWHITE64/Librarian-AP/releases/download/{{version}}/librarian.apworld"
 


### PR DESCRIPTION
It doesn't seem like the latest apworld is going to pass the tests so I made a new PR to at least fix the name for any players wanting to play in the upcoming cjya sync
Players will need to downgrade Librarian to v1.0.11 but the content between versions remains the same