### PR TITLE
Remove Earthbound exclusion

### DIFF
--- a/index/earthbound.toml
+++ b/index/earthbound.toml
@@ -1,4 +1,4 @@
 name = "EarthBound"
-# The author has publicly expressed their hatred for this project and adjacent ones, going as far as expressing their will to find a way to get excluded from it. Respect their wish
-disabled = true
+home = "https://archipelago.gg"
+supported = true
 


### PR DESCRIPTION
I had a look into the Earthbound exclusion and spoke to the core author of it, Pink Switch.

Issues relate to their experiences with Eijebong, and don't extend to what Ionium is now that they aren't involved, so I'm proposing to remove the exclusion. World will still need to go through the usual fuzzer testing first.

Included the relevant part of the conversation.

> I never wanted it excluded in the first place I would like all of my worlds on there and me unbanned from using the site please
Well to be clear I made a statement that I didn’t want it afterwards because I was mad at eije and didn’t want to deal with it anymore
But he removed them and then lied about me making a request to remove them
Feel free to request it I’m not going to open a pr because I’m kind of over it

I've kept this to Earthbound, but if acceptable, PRs for other worlds by the same author should be opened for:
- Yoshi's Island (core)
- Super Smash Bros. Melee