### PR TITLE
Disable all games that require a ROM to generate

### DIFF
--- a/index/alttp.toml
+++ b/index/alttp.toml
@@ -1,3 +1,4 @@
 name = "A Link to the Past"
 home = "https://archipelago.gg"
 supported = true
+disabled = true # Needs a ROM not supplied by the lobby

--- a/index/dkc3.toml
+++ b/index/dkc3.toml
@@ -1,3 +1,4 @@
 name = "Donkey Kong Country 3"
 home = "https://archipelago.gg"
 supported = true
+disabled = true # Needs a ROM not supplied by the lobby

--- a/index/lufia2ac.toml
+++ b/index/lufia2ac.toml
@@ -1,3 +1,4 @@
 name = "Lufia II Ancient Cave"
 home = "https://archipelago.gg"
 supported = true
+disabled = true # Needs a ROM not supplied by the lobby

--- a/index/mmbn3.toml
+++ b/index/mmbn3.toml
@@ -1,3 +1,4 @@
 name = "MegaMan Battle Network 3"
 home = "https://archipelago.gg"
 supported = true
+disabled = true # Needs a ROM not supplied by the lobby

--- a/index/smw.toml
+++ b/index/smw.toml
@@ -1,3 +1,4 @@
 name = "Super Mario World"
 home = "https://archipelago.gg"
 supported = true
+disabled = true # Needs a ROM not supplied by the lobby

--- a/index/soe.toml
+++ b/index/soe.toml
@@ -1,3 +1,4 @@
 name = "Secret of Evermore"
 home = "https://archipelago.gg"
 supported = true
+disabled = true # Needs a ROM not supplied by the lobby

--- a/index/tloz.toml
+++ b/index/tloz.toml
@@ -1,3 +1,4 @@
 name = "The Legend of Zelda"
 home = "https://archipelago.gg"
 supported = true
+disabled = true # Needs a ROM not supplied by the lobby

--- a/index/wl.toml
+++ b/index/wl.toml
@@ -1,6 +1,7 @@
 name = "Wario Land"
 home = "https://discord.com/channels/731205301247803413/1173641836502454303"
 default_url = "https://github.com/randomcodegen/Archipelago/releases/download/{{version}}/wl.apworld"
+disabled = true # Needs a ROM not supplied by the lobby
 
 [versions]
 "1.2.5" = {}

--- a/index/yoshisisland.toml
+++ b/index/yoshisisland.toml
@@ -1,3 +1,4 @@
 name = "Yoshi's Island"
-# The author has publicly expressed their hatred for this project and adjacent ones, going as far as expressing their will to find a way to get excluded from it. Respect their wish
-disabled = true
+home = "https://archipelago.gg"
+supported = true
+disabled = true # Needs a ROM not supplied by the lobby


### PR DESCRIPTION
The Ionium lobby currently does not supply any ROMs at generation time. Because of this, all games that require a ROM will fail to generate in the lobby. This PR disables all such games.