### PR TITLE
Add version 2.1.3 to deltarune.toml

### DIFF
--- a/index/deltarune.toml
+++ b/index/deltarune.toml
@@ -16,3 +16,4 @@ default_url = "https://github.com/theemeraldsword85/DELTARUNEAP/releases/downloa
 "2.0.3+hotfix1" = { url = "https://github.com/theemeraldsword85/DELTARUNEAP/releases/download/v2.0.3/deltarune.apworld" }
 "2.0.4" = {}
 "2.1.2" = {}
+"2.1.3" = {}


### PR DESCRIPTION
Small logic change but also removed mixing classification that should resolve the UT hook failures