### PR TITLE
Disable Severed Soul

### DIFF
--- a/index/severed_soul.toml
+++ b/index/severed_soul.toml
@@ -1,5 +1,6 @@
 name = "Severed Soul"
 home = "https://discord.com/channels/731205301247803413/1400131509569978478"
+disabled = true # Client spams the server with LocationChecks messages, 210000 over 3 hours (~19/s average).
 
 [versions]
 "2.6.0" = { url = "https://github.com/Grenhunterr/Archipelago/releases/download/v2.6/severed_soul.apworld" }


### PR DESCRIPTION
It was reported on 2026-03-07 to the developer that the Severed Soul client was spamming the server with LocationChecks messages, sending 210000 over a period of 3 hours (19.44 messages per second on average).

No release has been made since then, 5 months later, to address this issue.

Initial report on their discord thread in the Archipelago discord server https://discord.com/channels/731205301247803413/1400131509569978478/1479925273980834024

The issue comes from the fact that the client does not check that the locations it is sending are already checked, and that it sends each location in a separate LocationChecks message, instead of one message with all the locations to send, see https://github.com/Grenhunterr/Archipelago/blob/v2.7/worlds/severed_soul/client.py#L210-L213