### PR TITLE
Update URL for Manual: Super VR Ball

### DIFF
--- a/index/manual_supervrball_ellie53.toml
+++ b/index/manual_supervrball_ellie53.toml
@@ -3,4 +3,4 @@ display_name = "Manual: Super VR Ball"
 home = "https://discord.com/channels/1097532591650910289/1535631755342520410"
 
 [versions]
-"1.0.0+hotfix1" = {url = "https://github.com/Ellie53real/ellies-manuals/releases/download/SVRB-1.0.0/manual_supervrball_ellie53.apworld"}
+"1.0.0+hotfix1" = {url = "https://github.com/Ellie53real/ellies-manuals/releases/download/SVRB-v1.0.0/manual_supervrball_ellie53.apworld"}


### PR DESCRIPTION
This PR simply updates the URL for the Super VR Ball Manual; the APWorld itself is the exact same version currently included in the .toml (so no re-testing should be necessary), I just updated its release tag (and thus, the URL) to match the rest of the releases on the repository for my Manuals.