### PR TITLE
Update Manual: Lonely Wolf Treat: The Complete Series

### DIFF
--- a/index/manual_lonelywolftreatthecompleteseries_ellie53.toml
+++ b/index/manual_lonelywolftreatthecompleteseries_ellie53.toml
@@ -3,6 +3,6 @@ display_name = "Manual: Lonely Wolf Treat: The Complete Series"
 home = "https://discord.com/channels/1097532591650910289/1511115598162297012"
 
 [versions]
+"1.2.0" = {url = "https://github.com/Ellie53real/ellies-manuals/releases/download/LWT-v1.2.0/manual_lonelywolftreatthecompleteseries_ellie53.apworld"}
 "1.1.1" = {url = "https://github.com/Ellie53real/ellies-manuals/releases/download/LWT-v1.1.1/manual_lonelywolftreatthecompleteseries_ellie53.apworld"}
-"1.1.0" = {url = "https://github.com/Ellie53real/ellies-manuals/releases/download/LWT-v1.1.0/manual_lonelywolftreatthecompleteseries_ellie53.apworld"}
 "1.0.1" = {url = "https://github.com/Ellie53real/ellies-manuals/releases/download/LWT-v1.0.1/manual_lonelywolftreatthecompleteseries_ellie53.apworld"}

--- a/index/manual_lonelywolftreatthecompleteseries_ellie53.toml
+++ b/index/manual_lonelywolftreatthecompleteseries_ellie53.toml
@@ -3,6 +3,6 @@ display_name = "Manual: Lonely Wolf Treat: The Complete Series"
 home = "https://discord.com/channels/1097532591650910289/1511115598162297012"
 
 [versions]
-"1.2.0" = {url = "https://github.com/Ellie53real/ellies-manuals/releases/download/LWT-v1.2.0/manual_lonelywolftreatthecompleteseries_ellie53.apworld"}
+"1.2.0+hotfix" = {url = "https://github.com/Ellie53real/ellies-manuals/releases/download/LWT-v1.2.0%2Bhotfix/manual_lonelywolftreatthecompleteseries_ellie53.apworld"}
 "1.1.1" = {url = "https://github.com/Ellie53real/ellies-manuals/releases/download/LWT-v1.1.1/manual_lonelywolftreatthecompleteseries_ellie53.apworld"}
 "1.0.1" = {url = "https://github.com/Ellie53real/ellies-manuals/releases/download/LWT-v1.0.1/manual_lonelywolftreatthecompleteseries_ellie53.apworld"}


### PR DESCRIPTION
This PR adds version 1.2.0 to the .toml file for Manual: Lonely Wolf Treat: The Complete Series. This version mostly just updates the underlying Manual version used by the APWorld to the latest unstable build for faster generation times, but does also make a change that will be worth giving it a new test for regardless, to make sure it doesn't cause any new errors.

The PR also *removes* version 1.1.0 from the version list, as it introduced a logic bug that is fixed from version 1.1.1 onward.