### PR TITLE
Update Minecraft Fabric to 1.2.0

### DIFF
--- a/index/minecraft_fabric.toml
+++ b/index/minecraft_fabric.toml
@@ -1,9 +1,9 @@
 name = "Minecraft Fabric"
-home = "https://discord.com/channels/731205301247803413/1461461958040621241"
-default_url = "https://github.com/Deadlydiamond98/MinecraftFabricAPWorld/releases/download/v{{version}}/minecraft_fabric.apworld"
+home = "https://discord.com/channels/731205301247803413/1504088174492909679"
+default_url = "https://github.com/threecrowsinatrenchcrowt/MinecraftFabricAPWorld/releases/download/v{{version}}/minecraft_fabric.apworld"
 
 [versions]
-"1.0.6-alpha" = {}
 "1.0.7" = {url = "https://github.com/Deadlydiamond98/MinecraftFabricAPWorld/releases/download/v.1.0.7/minecraft_fabric.apworld"}
 "1.1.1+1" = { url = "https://github.com/Deadlydiamond98/MinecraftFabricAPWorld/releases/download/v.1.1.1.1/minecraft_fabric.apworld"}
-"1.1.2" = {}
+"1.1.2" = { url = "https://github.com/Deadlydiamond98/MinecraftFabricAPWorld/releases/download/v1.1.2/minecraft_fabric.apworld" }
+"1.2.0" = {}


### PR DESCRIPTION
It looks like maintainership of this APWorld has been taken over, hence the new default URL.
Also adds the new home URL.