### PR TITLE
Add Sonic Dreams Collection

### DIFF
--- a/index/sdc.toml
+++ b/index/sdc.toml
@@ -1,0 +1,7 @@
+name = "Sonic Dreams Collection"
+home = "https://discord.com/channels/1085716850370957462/1542687516887486545"
+default_url = "https://github.com/KitLemonfoot/ArchipelagoSDC/releases/download/v{{version}}/sdc.apworld"
+tags = ["ad"]
+
+[versions]
+"0.4.0" = {}


### PR DESCRIPTION
Yes, this is happening.
APWorld passed my own 10k fuzzing tests, so hopefully this should work.
NOTE: Some fuzzing tests can take a longer than normal time if the fuzzer rolls a very high `ascensions_to_goal` value.