### PR TITLE
Add SMO connected version of the rando instead of just a manual

### DIFF
--- a/index/SMO.toml
+++ b/index/SMO.toml
@@ -1,0 +1,8 @@
+name = "Super Mario Odyssey"
+
+home = "https://discord.com/channels/1345801058609270794/1537330671314411541"
+
+default_url = "https://github.com/AdalynBlack/SuperMarioOdysseyArchipelago/releases/download/v{{version}}/smo.apworld"
+
+[versions]
+"1.7.6-1" = {}


### PR DESCRIPTION
Add SMO connected version of the rando instead of a manual This is the Implementation of Super Mario Odyssey in the unofficial server. Which allows you to connect mario odyssey to the switch or emulator and fully send out checks and give locations without using a manual 

https://discord.gg/5QUC2Vb6up link to the discord


accidently removed the old pull request because of me deleting the fork on accident