### PR TITLE
Add STPPC 0.1.19 and change to new repo url

### DIFF
--- a/index/sgtpuzzles.toml
+++ b/index/sgtpuzzles.toml
@@ -1,6 +1,6 @@
 name = "Simon Tatham's Portable Puzzle Collection"
 home = "https://discord.com/channels/731205301247803413/1278733078516207719"
-default_url = "https://github.com/ishanpm/ap-sgtpuzzles/releases/download/v{{version}}/sgtpuzzles.apworld"
+default_url = "https://github.com/ishanpm/Archipelago-sgtpuzzles/releases/download/v{{version}}/sgtpuzzles.apworld"
 
 [versions]
 "0.1.8-prealpha" = { url = "https://github.com/ishanpm/ap-sgtpuzzles-web/releases/download/v0.1.8-prealpha/sgtpuzzles.apworld" }

--- a/index/sgtpuzzles.toml
+++ b/index/sgtpuzzles.toml
@@ -1,9 +1,10 @@
 name = "Simon Tatham's Portable Puzzle Collection"
 home = "https://discord.com/channels/731205301247803413/1278733078516207719"
-default_url = "https://github.com/ishanpm/ap-sgtpuzzles-web/releases/download/v{{version}}/sgtpuzzles.apworld"
+default_url = "https://github.com/ishanpm/ap-sgtpuzzles/releases/download/v{{version}}/sgtpuzzles.apworld"
 
 [versions]
-"0.1.8-prealpha" = {}
-"0.1.10-prealpha" = {}
-"0.1.11-prealpha" = {}
-"0.1.15-prealpha" = {}
+"0.1.8-prealpha" = {"https://github.com/ishanpm/ap-sgtpuzzles-web/releases/download/v0.1.8-prealpha/sgtpuzzles.apworld"}
+"0.1.10-prealpha" = {"https://github.com/ishanpm/ap-sgtpuzzles-web/releases/download/v0.1.10-prealpha/sgtpuzzles.apworld"}
+"0.1.11-prealpha" = {"https://github.com/ishanpm/ap-sgtpuzzles-web/releases/download/v0.1.11-prealpha/sgtpuzzles.apworld"}
+"0.1.15-prealpha" = {"https://github.com/ishanpm/ap-sgtpuzzles-web/releases/download/v0.1.15-prealpha/sgtpuzzles.apworld"}
+"0.1.19-prealpha" = {}

--- a/index/sgtpuzzles.toml
+++ b/index/sgtpuzzles.toml
@@ -3,8 +3,8 @@ home = "https://discord.com/channels/731205301247803413/1278733078516207719"
 default_url = "https://github.com/ishanpm/ap-sgtpuzzles/releases/download/v{{version}}/sgtpuzzles.apworld"
 
 [versions]
-"0.1.8-prealpha" = {"https://github.com/ishanpm/ap-sgtpuzzles-web/releases/download/v0.1.8-prealpha/sgtpuzzles.apworld"}
-"0.1.10-prealpha" = {"https://github.com/ishanpm/ap-sgtpuzzles-web/releases/download/v0.1.10-prealpha/sgtpuzzles.apworld"}
-"0.1.11-prealpha" = {"https://github.com/ishanpm/ap-sgtpuzzles-web/releases/download/v0.1.11-prealpha/sgtpuzzles.apworld"}
-"0.1.15-prealpha" = {"https://github.com/ishanpm/ap-sgtpuzzles-web/releases/download/v0.1.15-prealpha/sgtpuzzles.apworld"}
+"0.1.8-prealpha" = { url = "https://github.com/ishanpm/ap-sgtpuzzles-web/releases/download/v0.1.8-prealpha/sgtpuzzles.apworld" }
+"0.1.10-prealpha" = { url = "https://github.com/ishanpm/ap-sgtpuzzles-web/releases/download/v0.1.10-prealpha/sgtpuzzles.apworld" }
+"0.1.11-prealpha" = { url = "https://github.com/ishanpm/ap-sgtpuzzles-web/releases/download/v0.1.11-prealpha/sgtpuzzles.apworld" }
+"0.1.15-prealpha" = { url = "https://github.com/ishanpm/ap-sgtpuzzles-web/releases/download/v0.1.15-prealpha/sgtpuzzles.apworld" }
 "0.1.19-prealpha" = {}


### PR DESCRIPTION
Updated the default URL and added version links for several prealpha versions.