### PR TITLE
Add Mario Kart DS

### DIFF
--- a/index/mkds.toml
+++ b/index/mkds.toml
@@ -3,4 +3,4 @@ home = "https://github.com/SsL2727/mkds-archipelago"
 default_url = "https://github.com/SsL2727/mkds-archipelago/releases/download/{{version}}/mkds.apworld"
 
 [versions]
-"0.27.0" = {}
+"0.27.1" = {}

--- a/index/mkds.toml
+++ b/index/mkds.toml
@@ -1,0 +1,6 @@
+name = "Mario Kart DS"
+home = "https://github.com/SsL2727/mkds-archipelago"
+default_url = "https://github.com/SsL2727/mkds-archipelago/releases/download/{{version}}/mkds.apworld"
+
+[versions]
+"0.27.0" = {}

--- a/index/mkds.toml
+++ b/index/mkds.toml
@@ -3,4 +3,4 @@ home = "https://github.com/SsL2727/mkds-archipelago"
 default_url = "https://github.com/SsL2727/mkds-archipelago/releases/download/{{version}}/mkds.apworld"
 
 [versions]
-"0.27.1" = {}
+"0.27.2" = {}


### PR DESCRIPTION
Adds `mkds.toml` for Mario Kart DS (world module `mkds`), a from-scratch coded world (not a Manual) targeting the EU ROM via BizHawk's melonDS core - no ROM patching, live memory read/write for check detection and unlock enforcement.

- Repo: https://github.com/SsL2727/mkds-archipelago
- Release used: https://github.com/SsL2727/mkds-archipelago/releases/tag/0.27.0 (semver-tagged, `mkds.apworld` attached)
- No ROM is required to generate; the world only touches emulator memory at runtime via its BizHawk client, never during generation.
- No use of the raw `random` module (all randomization goes through the seeded `self.random`/`world.random`).