### PR TITLE
Remove After Dark tag from Touhou 6

### DIFF
--- a/index/th06.toml
+++ b/index/th06.toml
@@ -1,7 +1,6 @@
 name = "Touhou Koumakyou ~ the Embodiment of Scarlet Devil"
 home = "https://discord.com/channels/1085716850370957462/1353408740480778270"
 default_url = "https://github.com/Nepley/eosd-apworld/releases/download/v{{version}}/th06.apworld"
-tags = ["ad"]
 
 [versions]
 "1.3.2" = {}


### PR DESCRIPTION
The game has been re-released on steam in a nearly identical state, now with an official rating.

One of the lead mods has confirmed that this implementation is now allowed on the main Archipelago Discord
<img width="1204" height="1620" alt="image" src="https://github.com/user-attachments/assets/ad788b1c-d46a-470a-a2dc-a258bd548541" />

Full conversation on the After Dark server:
https://discord.com/channels/1085716850370957462/1353408740480778270/1547320526949589034
