### PR TITLE
Update Spicy Mycena 64 to v1.0.1

### DIFF
--- a/index/sm64ex_spicy.toml
+++ b/index/sm64ex_spicy.toml
@@ -8,3 +8,4 @@ default_url = "https://github.com/Alchav/Archipelago/releases/download/spicy-{{v
 "0.2.1" = {}
 "0.2.2" = {}
 "0.2.3" = {}
+"1.0.0" = {}

--- a/index/sm64ex_spicy.toml
+++ b/index/sm64ex_spicy.toml
@@ -8,4 +8,4 @@ default_url = "https://github.com/Alchav/Archipelago/releases/download/spicy-{{v
 "0.2.1" = {}
 "0.2.2" = {}
 "0.2.3" = {}
-"1.0.0" = {}
+"1.0.1" = {}


### PR DESCRIPTION
Should not contain the Gerpocolypse crash from #396 
The common FillError should also no longer occur since I fixed that alongside the Gerpocolypse fix.

### Fuzz notes.
Generation may take longer with various Entrance Shuffle combinations, with an average of about a minute with my PC.