### PR TITLE
Update rotn.toml through version 1.16.0

### DIFF
--- a/index/rotn.toml
+++ b/index/rotn.toml
@@ -7,3 +7,7 @@ default_url = "https://github.com/studkid/RiftArchipelago/releases/download/v{{v
 "0.10.0" = {}
 "0.11.0" = {}
 "0.12.0" = {}
+"0.13.0" = {}
+"0.14.0" = {}
+"0.15.0" = {}
+"0.16.0" = {}


### PR DESCRIPTION
I added the more recent versions of the Rift of the Necrodancer APWorld since currently it only goes up to 1.12.0 which is 4 versions behind what is most recent