### PR TITLE
Add Hollow Knight: Silksong (Batsong)

### DIFF
--- a/index/silksong_batsong.toml
+++ b/index/silksong_batsong.toml
@@ -1,0 +1,9 @@
+name = "Hollow Knight: Silksong"
+home = "https://discord.com/channels/731205301247803413/1540758118361727056"
+default_url = "https://github.com/Batatvideogames/silksong-archipelago-randomizer/releases/download/v{{version}}/silksong.apworld"
+
+[versions]
+"0.4.52" = { url = "https://github.com/Batatvideogames/silksong-archipelago-randomizer/releases/download/v0.4.5-Hotfix2/silksong.apworld" }
+"0.4.5" = { }
+"0.4.4" = { }
+"0.4.3" = { }


### PR DESCRIPTION
Adding support for Hollow Knight: Silksong (Batsong) implementation.

[Repository Link](https://github.com/Batatvideogames/silksong-archipelago-randomizer)
[Archipelago Channel Link](https://discord.com/channels/731205301247803413/1540758118361727056)

Additionally had to specify v0.4.52's version as the hotfix was tagged in the repository using "v0.4.5-Hotfix2".

It's worth noting for large asyncs sake that the WOTH implementation as of v0.4.5-Hotfix2 still is quite slow on generation times. I wasn't certain if this was a valid reason for denial.

It's best to disable this for any group larger than 3, if this ends up being a reason why this isn't merged then that's understandable. This is one of the things that should be addressed in one of the updates soon.